### PR TITLE
Maintain tab header container positioning when hiding ribbon

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -17,6 +17,9 @@
 .hider-ribbon .workspace-split.mod-left-split {
   margin-left:0;
 }
+.hider-ribbon.is-hidden-frameless:not(.is-fullscreen) .workspace-tabs.mod-top-left-space .workspace-tab-header-container {
+  padding-left: calc(var(--frame-left-space) + var(--ribbon-width));
+}
 
 /* Frameless */
 .hider-frameless .titlebar-button-container {


### PR DESCRIPTION
Thanks for the plugin!

When hiding the app ribbon, the contents of the tab header container (e.g. the icon to toggle the file explorer) collide with the window controls on macos.

Compensate by adding the ribbon width to the padding for the tab header container when hiding the ribbon.

I only tested on macos Monterrey (12.5), but I think the approach to maintain the preexisting position should play nicely with other OS window layouts. Let me know what you think, though.

**Before (collapsed)**
![collapsed-before](https://user-images.githubusercontent.com/93691/187704990-0a782110-07c4-4fd2-8beb-7cc3ff371a29.png)

**After (collapsed)**
![collapsed-after](https://user-images.githubusercontent.com/93691/187705010-b6c1582b-0141-4fcb-bffe-15e462e35711.png)

**Before (expanded)**
![expanded-before](https://user-images.githubusercontent.com/93691/187705035-d1b050a4-d5eb-417a-8439-440deca395df.png)

**After (expanded)**
![expanded-after](https://user-images.githubusercontent.com/93691/187705100-1fb9ce0a-d929-4010-b7eb-1eabeac3876e.png)
![expanded-after-annotated](https://user-images.githubusercontent.com/93691/187705121-1a889809-bdb7-4e4b-ac4e-9a27873cdd91.png)
