### PR TITLE
fix: update version and minAppVersion for releasing 1.3.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
 	"id": "obsidian-hider",
 	"name": "Hider",
-	"version": "1.2.5",
-	"minAppVersion": "0.16.0",
+	"version": "1.3.0",
+	"minAppVersion": "1.4.0",
 	"description": "Hide UI elements such as tooltips, status, titlebar and more",
 	"author": "@kepano",
 	"authorUrl": "https://www.twitter.com/kepano",


### PR DESCRIPTION
I have updated the obsidian-hider plugin but found the version info is not updated. The `manifest.json` need to update for release 1.3.0.