### PR TITLE
accumulate padding left instead of replacing the default when hiding tabs in macos

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -10,7 +10,7 @@ body.hider-vault:not(.is-mobile) .workspace-split.mod-left-split .workspace-side
 }
 
 .hider-tabs .mod-top-left-space .view-header {
-	padding-left: var(--frame-left-space);
+	padding-left: calc(var(--frame-left-space) + var(--size-4-3));
 }
 
 /* Hide sidebar buttons */


### PR DESCRIPTION
hey, really appreciate the plugin, been using it for years!

but I find myself always adding a css override to my setup, because the space for the window controls on macos is a tad bit too smol, 

if you highlight the `.view-header` element, you can see how it actually overlaps with the controls
<img width="704" height="258" alt="image" src="https://github.com/user-attachments/assets/94b866f3-35d4-4f1a-aba6-bf4b567f6672" />

So this PR bumps that by adding up the default `--size-4-3` that would be used in horizontal padding normally, with the `--frame-left-space` the code uses for the window controls.

https://github.com/user-attachments/assets/01674ae1-4072-466b-8fb4-795b196632c7

I can see a case being made for changing `--frame-left-space` directly, but I don't know what the side-effects of that would be, and if there are some other consumers to this variable, so I decided to fix the particular instance directly.


no ai was used for this 1 line PR, I just yap this much normally

